### PR TITLE
Bump asciidoctor-maven-plugin

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -59,7 +59,7 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>2.0.0-RC.1</version>
+                <version>2.0.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.jruby</groupId>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -98,6 +98,7 @@
                                 <idprefix />
                                 <idseparator>-</idseparator>
                                 <docinfo1>true</docinfo1>
+                                <imagesdir>images</imagesdir>
                             </attributes>
                         </configuration>
                     </execution>
@@ -125,6 +126,7 @@
                                 <idseparator>-</idseparator>
                                 <docinfo1>true</docinfo1>
                                 <embedAssets>true</embedAssets>
+                                <imagesdir>images</imagesdir>
                             </attributes>
                         </configuration>
                     </execution>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -59,7 +59,7 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>2.0.0</version>
+                <version>2.2.1</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.jruby</groupId>


### PR DESCRIPTION
https://github.com/asciidoctor/asciidoctor-maven-plugin/releases/tag/2.2.1

Between 2.0.0-rc1 and final 2.0.0 of the plugin following happened:
- asciidoctor/asciidoctor-maven-plugin#431

Per https://github.com/asciidoctor/asciidoctor-maven-plugin/pull/431#issuecomment-636489109:
> the value must be set explicitly
